### PR TITLE
Add __pairs Symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,29 @@ Coerces the value `x` to a number using JavaScript coercion rules.
 ### `instanceof(x, y)`
 
 Returns if the value `x` is an instance of the class `y` via use of the JavaScript [`instanceof` operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof)
+
+
+## Symbols
+
+### `__pairs`
+
+The `__pairs` Symbol can be used to describe how to iterate over a JavaScript object. Use `Symbol.for("__pairs")` to get the symbol. It should be used as a key on your objects, where the value is a function returning an object with three properties: `"iter"`, `"state"` and `"first"`.
+
+`"iter"` should be a function that follows the standard [Lua generic for protocol](http://www.lua.org/manual/5.3/manual.html#3.3.5), that is, it gets called with your *state* (as `this`) and the previous value produced; it should return an array of values or `undefined` if done.
+
+e.g. to make `pairs` on a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) return entries in the map via the [iterator symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator)
+
+```js
+Map.prototype[Symbol.for("__pairs")] = function() {
+	return {
+		iter: function(last) {
+			var v = this.next();
+			if (v.done) return;
+			return v.value;
+		},
+		state: this[Symbol.iterator]()
+	};
+}
+```
+
+A default `__pairs` is attached to `Object.prototype` that uses [`Object.keys`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys).


### PR DESCRIPTION
To allow customising `pairs` behaviour.

This can (should?) be extended with sensible __pairs for other standard JS classes.
  - Map
  - Array

Closes #1